### PR TITLE
qtype_essayautograde (issue #42) add missing call to static function

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -461,7 +461,7 @@ class qtype_essayautograde_renderer extends qtype_with_combined_feedback_rendere
 
                 // Plagiarism links, if any.
                 foreach ($currentresponse->plagiarism as $plagiarism) {
-                    $details[] = html_writer('p', $plagiarism);
+                    $details[] = html_writer::tag('p', $plagiarism);
                 }
 
                 if (empty($details) && $currentresponse->count) {


### PR DESCRIPTION
add missing call to static function "tag" in class html_writer
this was causing an exception when reviewing a quiz attempt