### PR TITLE
Fix review page renderer

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -62,6 +62,7 @@ class qtype_essayautograde_renderer extends qtype_with_combined_feedback_rendere
         }
 
         $renderer = $question->get_format_renderer($this->page);
+        $renderer->set_displayoptions($options);
         $linecount = $question->responsefieldlines;
 
         if ($readonly) {
@@ -921,7 +922,7 @@ class qtype_essayautograde_renderer extends qtype_with_combined_feedback_rendere
             if (count($phrases)) {
                 $output .= html_writer::alist($phrases, array('class' => 'targetphrases'));
             }
- 
+
             if ($question->errorcmid && ($cm = get_coursemodule_from_id('', $question->errorcmid))) {
                 $url = new moodle_url("/mod/{$cm->modname}/view.php?id={$cm->id}");
                 $a = (object)array(


### PR DESCRIPTION
Closes #68, #69 

Looks like the displayoptions have not been passed to the renderer. I'm not super familiar with the code, but this fixes the issue. I fixed this in current moodle master, php 8.0.

@mattgig also tested the fix on his instance