### PR TITLE
Fix essayautograde state verification with adjusted response text

### DIFF
--- a/tests/walkthrough_test.php
+++ b/tests/walkthrough_test.php
@@ -208,6 +208,7 @@ class qtype_essayautograde_walkthrough_testcase extends qbehaviour_walkthrough_t
 
         $prefix = $this->quba->get_field_prefix($this->slot);
         $fieldname = $prefix . 'answer';
+        $response = 'lorem ipsum';
 
         // Check the initial state.
         $this->check_current_state(question_state::$todo);
@@ -221,7 +222,7 @@ class qtype_essayautograde_walkthrough_testcase extends qbehaviour_walkthrough_t
         // Save.
         $this->quba->process_all_actions(null, array(
             'slots'                    => $this->slot,
-            $fieldname                 => 'Once upon a time there was a little green frog.',
+            $fieldname                 => $response,
             $fieldname . 'format'      => FORMAT_HTML,
             $prefix . ':sequencecheck' => '1',
         ));
@@ -231,7 +232,7 @@ class qtype_essayautograde_walkthrough_testcase extends qbehaviour_walkthrough_t
         $this->check_current_mark(null);
         $this->check_step_count(2);
         $this->render();
-        $this->check_contains_textarea('answer', 'Once upon a time there was a little green frog.');
+        $this->check_contains_textarea('answer', $response);
         $this->check_current_output(
                 $this->get_contains_question_text_expectation($q),
                 $this->get_does_not_contain_feedback_expectation());
@@ -244,8 +245,7 @@ class qtype_essayautograde_walkthrough_testcase extends qbehaviour_walkthrough_t
         $this->check_current_state(question_state::$gradedwrong);
         $this->check_current_mark(0.0);
         $this->render();
-        $this->assertMatchesRegularExpression('/' . preg_quote(s('Once upon a time there was a little green frog.'), '/') . '/',
-             $this->currentoutput);
+        $this->assertMatchesRegularExpression('/' . preg_quote(s($response), '/') . '/', $this->currentoutput);
         $this->check_current_output(
                 $this->get_contains_question_text_expectation($q),
                 $this->get_contains_general_feedback_expectation($q));


### PR DESCRIPTION
This PR reslves the #81 ,  where the `check_editorfield` method was incorrectly verifying the final state of question as `gaveup` instead of `gradedwrong`. The solution involved changing the response text to 'lorem ipsum', ensuring the similarity is less than 10% to achieve the correct `gradedwrong` state.

### Changes
- Updated the response text in the `check_editorfield` method to 'lorem ipsum' to ensure the similarity percentage remains below the threshold, resulting in the correct state verification of `gradedwrong`.

### Alternative Solutions
- Previous PR #82  also addresses the same issue with a different approach. Either of these PRs can be used to resolve the state verification problem.

